### PR TITLE
Use the r channel instead of asmeurer in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: topik
 channels:
-  - asmeurer
+  - r
   - chdoig
 dependencies:
   - blaze


### PR DESCRIPTION
The r channel is more stable than my channel, and should be preferred for
production environments.