### PR TITLE
Msarahan/es api rework

### DIFF
--- a/topik/__init__.py
+++ b/topik/__init__.py
@@ -1,0 +1,3 @@
+from .readers import read_input
+from .models import registered_models, load_model
+from .intermediaries.raw_data import registered_outputs, load_persisted_corpus

--- a/topik/intermediaries/raw_data.py
+++ b/topik/intermediaries/raw_data.py
@@ -13,6 +13,15 @@ from six import with_metaclass
 from topik.intermediaries.persistence import Persistor
 
 
+registered_outputs = {}
+
+def register_output(cls):
+    global registered_outputs
+    if cls.class_key() not in registered_outputs:
+        registered_outputs[cls.class_key()] = cls
+    return cls
+
+
 def _get_hash_identifier(input_data, id_field):
     return hash(input_data[id_field])
 
@@ -70,18 +79,13 @@ class CorpusInterface(with_metaclass(ABCMeta)):
         self.persistor.persist_data(filename)
 
 
+@register_output
 class ElasticSearchCorpus(CorpusInterface):
-    def __init__(self, host, index, content_field, port=9200, username=None,
-                 password=None, doc_type=None, query=None, iterable=None,
-                 filter_expression=""):
+    def __init__(self, source, index, content_field, doc_type=None, query=None, iterable=None,
+                 filter_expression="", **kwargs):
         super(ElasticSearchCorpus, self).__init__()
-        self.host = host
-        self.port = port
-        self.username = username
-        self.password = password
-        self.instance = Elasticsearch(hosts=[{"host": host, "port": port,
-                                              "http_auth": "{}:{}".format(username, password)}
-                                             ])
+        self.hosts = source
+        self.instance = Elasticsearch(hosts=source, **kwargs)
         self.index = index
         self.content_field = content_field
         self.doc_type = doc_type
@@ -124,9 +128,7 @@ class ElasticSearchCorpus(CorpusInterface):
            connection details."""
         if not field:
             field = self.content_field
-        return ElasticSearchCorpus(self.host, self.index, field, self.port,
-                                   self.username, self.password, self.doc_type,
-                                   self.query)
+        return ElasticSearchCorpus(self.hosts, self.index, field, self.doc_type, self.query)
 
     def import_from_iterable(self, iterable, id_field="text", batch_size=500):
         """Load data into Elasticsearch from iterable.
@@ -144,19 +146,27 @@ class ElasticSearchCorpus(CorpusInterface):
             if isinstance(item, basestring):
                 item = {id_field: item}
             id = _get_hash_identifier(item, id_field)
-            batch.append({"_id": id, "_source": item, "_type": "continuum"})
+            action = {'_op_type': 'update',
+                      '_index': self.index,
+                      '_type': 'continuum',
+                      '_id': id,
+                      'doc': item,
+                      'doc_as_upsert': "true",
+                      }
+            batch.append(action)
             if len(batch) >= batch_size:
                 helpers.bulk(client=self.instance, actions=batch, index=self.index)
                 batch = []
         if batch:
             helpers.bulk(client=self.instance, actions=batch, index=self.index)
+        self.instance.indices.refresh(self.index)
 
     def convert_date_field_and_reindex(self, field):
         index = self.index
         if self.instance.indices.get_field_mapping(field=field,
                                            index=index,
                                            doc_type="continuum") != 'date':
-            index = self.index+"_{}_date".format(field)
+            index = self.index+"_{}_alias_date".format(field)
             if not self.instance.indices.exists(index) or self.instance.indices.get_field_mapping(field=field,
                                            index=index,
                                            doc_type="continuum") != 'date':
@@ -166,6 +176,7 @@ class ElasticSearchCorpus(CorpusInterface):
                 self.instance.indices.put_alias(index=self.index,
                                                 name=index,
                                                 body=mapping)
+                self.instance.indices.refresh(index)
                 while self.instance.count(index=self.index) != self.instance.count(index=index):
                     logging.info("Waiting for date indexed data to be indexed...")
                     time.sleep(1)
@@ -174,23 +185,19 @@ class ElasticSearchCorpus(CorpusInterface):
     # TODO: validate input data to ensure that it has valid year data
     def get_date_filtered_data(self, start, end, field="date"):
         converted_index = self.convert_date_field_and_reindex(field=field)
-        return ElasticSearchCorpus(self.host, converted_index, self.content_field, self.port,
-                                   self.username, self.password, self.doc_type,
-                                   query={"query":
-                                          {"range":
-                                           {field:
-                                            {"gte": start,
-                                             "lte": end}}}},
+        return ElasticSearchCorpus(self.hosts, converted_index, self.content_field, self.doc_type,
+                                   query={"query": {"filtered": {"filter": {"range": {field: {"gte": start,
+                                                                                              "lte": end}}}}}},
                                    filter_expression=self.filter_expression + "_date_{}_{}".format(start, end))
 
     def save(self, filename, saved_data=None):
         if saved_data is None:
-            saved_data = {"host": self.host, "port": self.port, "index": self.index,
-                          "content_field": self.content_field, "username": self.username,
-                          "password": self.password, "doc_type": self.doc_type, "query": self.query}
+            saved_data = {"source": self.hosts, "index": self.index, "content_field": self.content_field,
+                          "doc_type": self.doc_type, "query": self.query}
         return super(ElasticSearchCorpus, self).save(filename, saved_data)
 
 
+@register_output
 class DictionaryCorpus(CorpusInterface):
     def __init__(self, content_field, iterable=None, generate_id=True, reference_field=None, content_filter=None):
         super(DictionaryCorpus, self).__init__()
@@ -275,11 +282,7 @@ class DictionaryCorpus(CorpusInterface):
                           "iterable": [doc["_source"] for doc in self._documents]}
         return super(DictionaryCorpus, self).save(filename, saved_data)
 
-# Collection of output formats: people put files, folders, etc in, and they can choose from these to be the output
-# These consume the iterable collection of dictionaries produced by the various iter_ functions.
-output_formats = {cls.class_key(): cls for cls in CorpusInterface.__subclasses__()}
-
 
 def load_persisted_corpus(filename):
     corpus_dict = Persistor(filename).get_corpus_dict()
-    return output_formats[corpus_dict['class']](**corpus_dict["saved_data"])
+    return registered_outputs[corpus_dict['class']](**corpus_dict["saved_data"])

--- a/topik/readers.py
+++ b/topik/readers.py
@@ -225,7 +225,7 @@ def _iter_elastic_query(hosts, **kwargs):
 
     Parameters
     ----------
-    es_full_path: string or list
+    hosts: string or list
         Address of the elasticsearch instance any index.  May include port, username and password.
         See https://elasticsearch-py.readthedocs.org/en/master/api.html#elasticsearch for all options.
 

--- a/topik/tests/test_raw_data_formats.py
+++ b/topik/tests/test_raw_data_formats.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import time
 
 import elasticsearch
 
@@ -53,12 +54,13 @@ class TestElasticSearchCorpus(unittest.TestCase, BaseCorpus):
         self.test_raw_data = read_input('{}/test_data_json_stream.json'.format(
             test_data_path), content_field="abstract",
             output_type=ElasticSearchCorpus.class_key(),
-            output_args= {'host': 'localhost',
-                          'index': INDEX},
+            output_args={'source': 'localhost',
+                         'index': INDEX},
             synchronous_wait=30)
 
     def tearDown(self):
         instance = elasticsearch.Elasticsearch("localhost")
         instance.indices.delete(INDEX)
-        if instance.indices.exists("{}_year_date".format(INDEX)):
-            instance.indices.delete("{}_year_date".format(INDEX))
+        if instance.indices.exists("{}_year_alias_date".format(INDEX)):
+            instance.indices.delete("{}_year_alias_date".format(INDEX))
+        time.sleep(1)

--- a/topik/tests/test_readers.py
+++ b/topik/tests/test_readers.py
@@ -87,14 +87,14 @@ class TestReader(unittest.TestCase):
         self.assertEqual(first_text, self.solution_3)
 
     def test_elastic_import(self):
-        output_args = {'host': 'localhost',
+        output_args = {'source': 'localhost',
                        'index': INDEX}
         # import data from file into known elastic server
         read_input('{}/test_data_json_stream.json'.format(
                    test_data_path), content_field="abstract",
                    output_type=ElasticSearchCorpus.class_key(),
                    output_args=output_args, synchronous_wait=30)
-        iterable_data = read_input("localhost:9200/"+INDEX, content_field="abstract")
+        iterable_data = read_input("localhost", source_type="elastic", content_field="abstract", index=INDEX)
         self.assertEquals(len(iterable_data), 100)
 
 


### PR DESCRIPTION
This does corpus output class registration the same way that the models do it, which will be more extensible for external users in the future (the old way would have required monkeypatching for them to extend the dictionary.  This way, they decorate their class and ensure that their module is imported prior to looking for their class in the dictionary.  This changes the name of the dictionary from output_formats to registered_outputs

This exposes some of the deeper functionality directly on the top-level topik object.  If topik gets overly complicated, this may end up being a design flaw.  For now, it simplifies imports.

