### PR TITLE
Youngblood/cli fixes

### DIFF
--- a/docs/example.rst
+++ b/docs/example.rst
@@ -75,8 +75,8 @@ accessible in python:
 
 .. code-block:: python
 
-   >>> from topik.simple_run.run import run_model
-   >>> run_model("./reviews/", content_field="text")
+   >>> from topik.simple_run.run import run_pipeline
+   >>> run_pipeline("./reviews/", content_field="text")
 
 
 Custom topic modeling flow

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -98,6 +98,6 @@ An example complete workflow would be the following:
    >>> raw_data = ((hash(item[content_field]), item[content_field]) for item in raw_data)
    >>> tokenized_corpus = tokenize(raw_data)
    >>> vectorized_corpus = vectorize(tokenized_corpus)
-   >>> n_topics = 10
-   >>> model = run_model(vectorized_corpus, n_topics)
+   >>> ntopics = 10
+   >>> model = run_model(vectorized_corpus, ntopics=ntopics)
    >>> plot = visualize(model)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,3 @@ There is also the option of just installing the Python features with pip.
    $ pip install topik
 
 
-.. warning::
-
-   The pip installation option will not provide all the available features, e.g. the LDAvis R package will not be
-   available.

--- a/docs/projects.rst
+++ b/docs/projects.rst
@@ -20,12 +20,13 @@ However, this does not handle any kind of persistence to disk.  Your changes wil
 
 .. code-block:: python
 
+    >>> from topik import TopikProject
     >>> with TopikProject("my_project") as project:
     >>>     project.read_input("./reviews/", content_field="text")
     >>>     project.tokenize()
     >>>     project.vectorize()
-    >>>     project.model(ntopics=4)
-    >>>     project.plot()
+    >>>     project.run_model(ntopics=4)
+    >>>     project.visualize()
     >>> # when project goes out of scope, any files are flushed to disk, and the project can later be loaded.
 
 
@@ -35,7 +36,7 @@ Projects create files on disk when instantiated if none already exist.  When pro
 .. code-block:: python
 
     >>> with TopikProject("my_project") as project:
-    >>>     project.plot()
+    >>>     project.visualize()
 
 
 Output formats

--- a/docs/vectorization.rst
+++ b/docs/vectorization.rst
@@ -28,6 +28,8 @@ on how much they occur in a single document, but also how much they occur across
 Words that occur many times in one document, but not much over the corpus are deemed to be more
 important under this scheme.
 
+NOTE: TF-IDF is NOT compatible with LDA models as Bag-Of-Words vectorization is a fundamental assumption of LDA.
+
 .. code-block:: python
 
     >>> from topik import vectorize

--- a/topik/__init__.py
+++ b/topik/__init__.py
@@ -6,6 +6,7 @@ from topik.tokenizers import tokenize
 from topik.vectorizers import vectorize
 from topik.transformers import transform
 from topik.models import run_model
+from topik.visualizers import visualize
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/topik/fileio/project.py
+++ b/topik/fileio/project.py
@@ -146,17 +146,20 @@ class TopikProject(object):
         # set _vectorizer_id internal handle to point to this data
         self._selected_vectorized_corpus_id = vectorize_parameter_string
 
-    def run_model(self, model_name="plsa", **kwargs):
+    def run_model(self, model_name="plsa", ntopics=3, **kwargs):
         """Analyze vectorized text; determine topics and assign document probabilities"""
+        if (model_name=='lda') and ('tfidf' in self._selected_vectorized_corpus_id):
+            raise ValueError('LDA models are incompatible with TF-IDF vectorization.  If you wish to use TFIDF vectorization, please select another type of model.')
         modeled_corpus = models.run_model(self.selected_vectorized_corpus,
-                                        model_name=model_name, **kwargs)
+                                          model_name=model_name,
+                                          ntopics=ntopics, **kwargs)
         model_id = "_".join([model_name, _get_parameters_string(**kwargs)])
         # store this internally
         self.output.modeled_corpora[model_id] = modeled_corpus
         # set _model_id internal handle to point to this data
         self._selected_modeled_corpus_id = model_id
 
-    def visualize(self, vis_name='termite', model_id=None, **kwargs):
+    def visualize(self, vis_name='lda_vis', model_id=None, **kwargs):
         """Plot model output"""
         if not model_id:
             modeled_corpus = self.selected_modeled_corpus

--- a/topik/fileio/tests/test_project.py
+++ b/topik/fileio/tests/test_project.py
@@ -95,7 +95,7 @@ class ProjectTest(object):
         self.project.tokenize()
         self.project.vectorize(method='tfidf')
         self.project.run_model(ntopics=2)
-        self.project.visualize(topn=5)
+        self.project.visualize(vis_name='termite', topn=5)
 
 
 class TestInMemoryOutput(unittest.TestCase, ProjectTest):

--- a/topik/models/_registry.py
+++ b/topik/models/_registry.py
@@ -25,5 +25,5 @@ register = partial(_base_register_decorator, registered_models)
 
 
 # this function is the primary API for people using any registered functions.
-def run_model(input_data, model_name, **kwargs):
-    return registered_models[model_name](input_data, **kwargs)
+def run_model(input_data, model_name='plsa', ntopics=3, **kwargs):
+    return registered_models[model_name](input_data, ntopics, **kwargs)

--- a/topik/models/plsa.py
+++ b/topik/models/plsa.py
@@ -85,6 +85,6 @@ def _PLSA(vectorized_corpus, ntopics, max_iter):
 
 @register
 def plsa(vectorized_corpus, ntopics, max_iter=100, **kwargs):
-    return ModelOutput(vectorized_corpus, _PLSA, ntopics=ntopics, max_iter=max_iter, **kwargs)
+    return ModelOutput(vectorized_corpus=vectorized_corpus, model_func=_PLSA, ntopics=ntopics, max_iter=max_iter, **kwargs)
 
 

--- a/topik/simple_run/cli.py
+++ b/topik/simple_run/cli.py
@@ -1,6 +1,6 @@
 import click
 
-from topik.simple_run.run import run_model
+from topik.simple_run.run import run_pipeline
 
 
 @click.command(help='Run topic modeling')
@@ -17,5 +17,5 @@ from topik.simple_run.run import run_model
 @click.option("--termite", help="Whether to output a termite plot as a result", default=True)
 @click.option("--ldavis", help="Whether to output an LDAvis-type plot as a result", default=False)
 def run(data, format, output, tokenizer, ntopics, field, model, termite, ldavis):
-    run_model(data_source=data, source_type=format, dir_path=output, tokenizer=tokenizer, n_topics=ntopics,
+    run_pipeline(data_source=data, source_type=format, dir_path=output, tokenizer=tokenizer, n_topics=ntopics,
               content_field=field, model=model, r_ldavis=ldavis, termite_plot=termite)

--- a/topik/simple_run/run.py
+++ b/topik/simple_run/run.py
@@ -17,8 +17,8 @@ BASEDIR = os.path.abspath(os.path.dirname(__file__))
 
 def run_pipeline(data_source, source_type="auto", year_field=None, start_year=None, stop_year=None,
               content_field=None, tokenizer='simple', vectorizer='bag_of_words', ntopics=10,
-              dir_path='./topic_model', model='lda', termite_plot=True, output_file=False,
-              ldavis=False, seed=42, **kwargs):
+              dir_path='./topic_model', model='lda', termite_plot=False, output_file=False,
+              lda_vis=True, seed=42, **kwargs):
 
     """Run your data through all topik functionality and save all results to a specified directory.
 
@@ -71,7 +71,7 @@ def run_pipeline(data_source, source_type="auto", year_field=None, start_year=No
     if termite_plot:
         termite_html(model, filename="termite.html", plot_title="Termite plot", topn=15)
 
-    if ldavis:
+    if lda_vis:
         visualizers.visualize(model, "lda_vis")
 
 

--- a/topik/simple_run/run.py
+++ b/topik/simple_run/run.py
@@ -72,6 +72,6 @@ def run_model(data_source, source_type="auto", year_field=None, start_year=None,
         termite_html(model, filename="termite.html", plot_title="Termite plot", topn=15)
 
     if ldavis:
-        visualizers["lda_vis"](model)
+        visualizers.visualize(model, "lda_vis")
 
 

--- a/topik/simple_run/run.py
+++ b/topik/simple_run/run.py
@@ -15,7 +15,7 @@ logging.basicConfig(format='%(asctime)s : %(levelname)s : %(message)s',
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
 
 
-def run_model(data_source, source_type="auto", year_field=None, start_year=None, stop_year=None,
+def run_pipeline(data_source, source_type="auto", year_field=None, start_year=None, stop_year=None,
               content_field=None, tokenizer='simple', vectorizer='bag_of_words', ntopics=10,
               dir_path='./topic_model', model='lda', termite_plot=True, output_file=False,
               ldavis=False, seed=42, **kwargs):

--- a/topik/simple_run/tests/test_run_api.py
+++ b/topik/simple_run/tests/test_run_api.py
@@ -5,6 +5,7 @@ from topik.fileio.tests import test_data_path
 
 
 def test_run():
-    run_pipeline(os.path.join(test_data_path, "test_data_json_stream.json"), content_field="abstract")
+    run_pipeline(os.path.join(test_data_path, "test_data_json_stream.json"), content_field="abstract",
+                 termite_plot=True, lda_vis=False)
     assert os.path.isfile("termite.html")
     os.remove("termite.html")

--- a/topik/simple_run/tests/test_run_api.py
+++ b/topik/simple_run/tests/test_run_api.py
@@ -1,10 +1,10 @@
 import os
 
-from topik.simple_run.run import run_model
+from topik.simple_run.run import run_pipeline
 from topik.fileio.tests import test_data_path
 
 
 def test_run():
-    run_model(os.path.join(test_data_path, "test_data_json_stream.json"), content_field="abstract")
+    run_pipeline(os.path.join(test_data_path, "test_data_json_stream.json"), content_field="abstract")
     assert os.path.isfile("termite.html")
     os.remove("termite.html")

--- a/topik/vectorizers/_registry.py
+++ b/topik/vectorizers/_registry.py
@@ -24,7 +24,7 @@ registered_vectorizers = VectorizerRegistry()
 register = partial(_base_register_decorator, registered_vectorizers)
 
 
-def vectorize(corpus, method="tfidf", **kwargs):
+def vectorize(corpus, method="bag_of_words", **kwargs):
     """Represent documents as vectors in word-space.
 
     Note: bag-of-words model is implicitly used when no additional


### PR DESCRIPTION
-renames run.run_model to run.run_pipeline, updates imports and function calls accordingly
-changes default visualization for run_pipeline to lda_vis
-fixes some default parameters in models.run_model
-minor updates to documentation code examples
-prevents TFIDF/LDA combination when using projects
   -(full fix including storage of corpus parameter strings coming in separate PR)